### PR TITLE
Updates for nodejs express version >= 4.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ in the step "Database Setup", and modify codeface.conf accordingly.
   list is for sufficient for a pristine default installation of
   Ubuntu 12.04 Desktop):
 
-         # Generic packages
+         # Generic packages (Required nodejs express version >= 4.0)
          sudo apt-get install python-mysqldb sinntp texlive default-jdk \
                               mysql-common mysql-client mysql-server python-dev \
                               exuberant-ctags nodejs npm git subversion \
@@ -155,7 +155,7 @@ See `bugextractor/INSTALL` for all java-related details.
 
 * The ID service requires a few node.js packages. Install them by running
 
-        npm install addressparser express js-yaml mysql
+        npm install addressparser express js-yaml mysql body-parser
 
   in the `id_service` directory.
 

--- a/id_service/id_service.js
+++ b/id_service/id_service.js
@@ -21,6 +21,7 @@ var mysql = require('mysql');
 var yaml = require("js-yaml");
 var logger = require('./logger');
 var addressparser = require("addressparser");
+var bodyparser = require("body-parser");
 
 // get property file name
 var fileName = process.argv[2];
@@ -63,10 +64,9 @@ var db_config = {
 };
 var pool = mysql.createPool(db_config)
 
-app.configure(function() {
-    // used to parse JSON object given in the body request
-    app.use(express.bodyParser());
-});
+// used to parse JSON object given in the body request
+app.use(bodyparser.urlencoded({ extended: false }));
+app.use(bodyparser.json());
 
 /**
  * Obtain a connection from the pool, check if it works, and then execute


### PR DESCRIPTION
Adapt code and installation guidelines to changes of nodejs express 3.x to 4.x.

Main changes:
1) Middleware "body-parser" is no longer bundled with nodejs express (>=4.0) and has to be installed separately.
2) Method "app.configure()" is no longer available in nodejs express. (https://github.com/strongloop/express/wiki/Migrating-from-3.x-to-4.x)
