### PR TITLE
Make the integration tests run across time-zones.

### DIFF
--- a/codeface/test/integration/example_projects.py
+++ b/codeface/test/integration/example_projects.py
@@ -404,7 +404,7 @@ int main() { // Adam
             },
             signoff=[Adam])
     project.tag_rc(Adam, "2013-01-08T15:30:00")
-    project.commit(Peter, Peter, "2013-01-09T15:30:00",
+    project.commit(Peter, Peter, "2013-01-09T15:30:00+01:00",
             {"src/carp.c":'''\
 int main() { // Adam
  int a; // Adam


### PR DESCRIPTION
Because in example projects no timezones where specified git would just use the system default.
This would lead to different SHA1 hash codes of the commits and therefore to failing tests.
The changes in this commit fix this problem in the following way:
- Only allowing ISO8601 dates (to simplify the implementation; other formats are not used anyway)
- Set a default timezone (+01:00) if no timezone is given
- Set the GIT_AUTHOR_DATE value (as this value is also significant for the hash value, but cannot be set on the command line)
- We use the timezone explicity one time in the integration test to make sure that this still works (so future tests can depend on different timezones if needed).