### PR TITLE
Add --reuse-vcs-analysis parameter to reuse an already existing vcs-analysis.db file.

### DIFF
--- a/codeface/cli.py
+++ b/codeface/cli.py
@@ -74,6 +74,11 @@ def get_parser():
                         help="Force a delete of the project in the database")
     run_parser.add_argument('--profile-r', action="store_true",
                         help="Compute an execution time profile for R code")
+    run_parser.add_argument(
+        '--reuse-vcs-analysis', action='store_true', dest="reuse_db",
+        help="Re-use an already existing vcs-analysis.db file. "
+             "This flag is useful to continue a previously failed analysis"
+             " or for debugging purposes.")
 
     ml_parser = sub_parser.add_parser('ml', help='Run mailing list analysis')
     ml_parser.set_defaults(func=cmd_ml)
@@ -109,7 +114,7 @@ def cmd_run(args):
         logfile = os.path.abspath(logfile)
     project_analyse(resdir, gitdir, codeface_conf, project_conf,
                     args.no_report, args.loglevel, logfile, args.recreate,
-                    args.profile_r, args.jobs, args.tagging)
+                    args.profile_r, args.jobs, args.tagging, args.reuse_db)
     return 0
 
 def cmd_ml(args):

--- a/codeface/cluster/cluster.py
+++ b/codeface/cluster/cluster.py
@@ -1779,16 +1779,19 @@ def computeSimilarity(cmtlist):
 # Main part
 ###########################################################################
 def performAnalysis(conf, dbm, dbfilename, git_repo, revrange, subsys_descr,
-                    create_db, outdir, limit_history,
+                    reuse_db, outdir, limit_history,
                     range_by_date, rcranges=None):
     link_type = conf["tagging"]
 
-    if create_db == True:
+    if not reuse_db or not os.path.isfile(dbfilename):
         log.devinfo("Creating data base for {0}..{1}".format(revrange[0],
                                                         revrange[1]))
         createDB(dbfilename, git_repo, revrange, subsys_descr, \
                  link_type, range_by_date, rcranges)
-
+    else:
+        log.warning("REUSING data base for {0}..{1} "
+                    "(make sure it is up to date)"
+                    .format(revrange[0], revrange[1]))
     projectID = dbm.getProjectID(conf["project"], conf["tagging"])
     revisionIDs = (dbm.getRevisionID(projectID, revrange[0]),
                    dbm.getRevisionID(projectID, revrange[1]))
@@ -1873,7 +1876,7 @@ def performAnalysis(conf, dbm, dbfilename, git_repo, revrange, subsys_descr,
 
 ##################################################################
 def doProjectAnalysis(conf, from_rev, to_rev, rc_start, outdir,
-                      git_repo, create_db, limit_history, range_by_date):
+                      git_repo, reuse_db, limit_history, range_by_date):
     #--------------
     #folder setup
     #--------------
@@ -1896,7 +1899,7 @@ def doProjectAnalysis(conf, from_rev, to_rev, rc_start, outdir,
     filename = os.path.join(outdir, "vcs_analysis.db")
     dbm = DBManager(conf)
     performAnalysis(conf, dbm, filename, git_repo, [from_rev, to_rev],
-                    None, create_db, outdir, limit_history, range_by_date,
+                    None, reuse_db, outdir, limit_history, range_by_date,
                     rc_range)
 
 ##################################

--- a/codeface/project.py
+++ b/codeface/project.py
@@ -52,7 +52,7 @@ def project_setup(conf, recreate):
 
 def project_analyse(resdir, gitdir, codeface_conf, project_conf,
                     no_report, loglevel, logfile, recreate, profile_r,
-                    n_jobs, tagging_type):
+                    n_jobs, tagging_type, reuse_db):
     pool = BatchJobPool(int(n_jobs))
     conf = Configuration.load(codeface_conf, project_conf)
     tagging = conf["tagging"]
@@ -105,7 +105,7 @@ def project_analyse(resdir, gitdir, codeface_conf, project_conf,
         s1 = pool.add(
                 doProjectAnalysis,
                 (conf, start_rev, end_rev, rc_rev, range_resdir, repo,
-                    True, True, range_by_date),
+                    reuse_db, True, range_by_date),
                 startmsg=prefix + "Analysing commits...",
                 endmsg=prefix + "Commit analysis done."
             )


### PR DESCRIPTION
The code to re-use the file was already implemented and is quite useful for continuing a failed analysis or debugging purposes.
The requirement to edit code to enable this is just a unnecessary hurdle.