### PR TITLE
Ignore crashing cppstats

### DIFF
--- a/codeface/test/unit/test_cppstats_works.py
+++ b/codeface/test/unit/test_cppstats_works.py
@@ -51,6 +51,14 @@ class TestCppStatsWorks(unittest.TestCase):
         self.assertEqual(file, file_new)
 
     def test_simple_analysis(self):
+        """
+        This test checks if cppstats is working as expected.
+        When this test fails it is possible that cppstats doesn't have
+        a working srcML binary. You can find the binaries on
+        http://sdml.info/lmcrs/ . Just copy the right binary to
+        cppstats/lib/srcml/{win|linux|darwin} and replace the
+        existing ones, then run this test again.
+        """
         file="""
 #if Test
 // example


### PR DESCRIPTION
This is basically https://github.com/siemens/codeface/pull/22. Somehow this fix slipped through and is not in the master or mitchell-updates branch...See #22 for a detailed analysis. I will use the master branch (because it is up2date now) for this pull request, let me know if this is correct.