### PR TITLE
Add "FeatureExpression" as commit dependency

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,7 @@ res/
 testdat/
 performance/results/
 *.tar.gz
+.idea/
+id_service/node_modules/
+*.Rproj
+.Rproj.user/

--- a/codeface/fileCommit.py
+++ b/codeface/fileCommit.py
@@ -119,8 +119,9 @@ class FileCommit:
         # meta data
         self._src_elem_list = []
 
-        # dictionary with key = line number, value = feature list
+        # dictionaries with key = line number, value = feature list|feature expression
         self.feature_info = FileDict()
+        self.feature_expression_info = FileDict()
 
     #Getter/Setters
     def getFileSnapShots(self):
@@ -154,7 +155,8 @@ class FileCommit:
         self._src_elem_list.extend(src_elem_list)
 
     def set_feature_infos(self, feature_line_infos):
-        self.feature_info = feature_line_infos
+        self.feature_info = feature_line_infos[0]
+        self.feature_expression_info = feature_line_infos[1]
 
     #Methods
     def addFileSnapShot(self, key, dict):
@@ -191,3 +193,6 @@ class FileCommit:
 
     def findFeatureList(self, line_index):
         return self.feature_info.get_line_info(int(line_index) + 1)
+
+    def findFeatureExpression(self, line_index):
+        return self.feature_expression_info.get_line_info(int(line_index) + 1)

--- a/codeface/test/integration/test_features.py
+++ b/codeface/test/integration/test_features.py
@@ -208,16 +208,22 @@ class TestEndToEndOnlyTaggingExample3Feature(
              'A', 'Feature', 1, None),
             ('f95b8047236f75641d6d7a2b5790b9e1db869ccd', 'src/carp.c',
              'B', 'Feature', 1, None),
+            ('f95b8047236f75641d6d7a2b5790b9e1db869ccd', 'src/carp.c',
+            '(defined(A) || defined(B))', 'FeatureExpression', 1, None),
 
             ('7b16cf10845bc64e2589fa63822f3ddc49aedd4d', 'src/carp.c',
              'A', 'Feature', 1, None),
             ('7b16cf10845bc64e2589fa63822f3ddc49aedd4d', 'src/carp.c',
              'B', 'Feature', 1, None),
+            ('7b16cf10845bc64e2589fa63822f3ddc49aedd4d', 'src/carp.c',
+            '(defined(A) || defined(B))', 'FeatureExpression', 1, None),
 
             ('3fe9884f98487cce4603d2bd5578e94944412d3c', 'src/carp.c',
              'A', 'Feature', 1, None),
             ('3fe9884f98487cce4603d2bd5578e94944412d3c', 'src/carp.c',
              'B', 'Feature', 1, None),
+            ('3fe9884f98487cce4603d2bd5578e94944412d3c', 'src/carp.c',
+            '(defined(A) || defined(B))', 'FeatureExpression', 1, None),
 
             # Release 2 (see blame data above)
             ('c9b59046b6eb473b97a97cb31aded2deced29dc6', 'src/code.c',
@@ -226,20 +232,37 @@ class TestEndToEndOnlyTaggingExample3Feature(
              'B', 'Feature', 3, None),
             ('c9b59046b6eb473b97a97cb31aded2deced29dc6', 'src/code.c',
              'C', 'Feature', 2, None),
+            ('c9b59046b6eb473b97a97cb31aded2deced29dc6', 'src/code.c',
+            '(defined(C))', 'FeatureExpression', 2, None),
+            ('c9b59046b6eb473b97a97cb31aded2deced29dc6', 'src/code.c',
+            '(defined(A))', 'FeatureExpression', 1, None),
+            ('c9b59046b6eb473b97a97cb31aded2deced29dc6', 'src/code.c',
+            '(!((defined(A)))) && ((defined(B)))', 'FeatureExpression', 1, None),
+            ('c9b59046b6eb473b97a97cb31aded2deced29dc6', 'src/code.c',
+            '(!((defined(A)))) && (!((defined(B))))', 'FeatureExpression', 2, None),
 
             ('29b9c8bc6955df51263201dff7a1d935f8cd6049', 'src/code.c',
              'C', 'Feature', 1, None),
+            ('29b9c8bc6955df51263201dff7a1d935f8cd6049', 'src/code.c',
+            '(defined(C))', 'FeatureExpression', 1, None),
 
             ('c52343ac0d17ce9a30866d296da0deb23f1567a7', 'src/code.c',
              'A', 'Feature', 3, None),
             ('c52343ac0d17ce9a30866d296da0deb23f1567a7', 'src/code.c',
              'B', 'Feature', 2, None),
-
+            ('c52343ac0d17ce9a30866d296da0deb23f1567a7', 'src/code.c',
+            '(defined(A))', 'FeatureExpression', 1, None),
+            ('c52343ac0d17ce9a30866d296da0deb23f1567a7', 'src/code.c',
+            '(!((defined(A)))) && ((defined(B)))', 'FeatureExpression', 1, None),
+            ('c52343ac0d17ce9a30866d296da0deb23f1567a7', 'src/code.c',
+            '(!((defined(A)))) && (!((defined(B))))', 'FeatureExpression', 1, None),
 
             ('55eec10019857e44d80e4bec3e81d1cffb785592', 'src/carp.c',
              'A', 'Feature', 1, None),
             ('55eec10019857e44d80e4bec3e81d1cffb785592', 'src/carp.c',
-             'B', 'Feature', 1, None)
+             'B', 'Feature', 1, None),
+            ('55eec10019857e44d80e4bec3e81d1cffb785592', 'src/carp.c',
+            '(defined(A) || defined(B))', 'FeatureExpression', 1, None)
         ]
 
 

--- a/codeface/test/unit/test_cppstats_works.py
+++ b/codeface/test/unit/test_cppstats_works.py
@@ -67,7 +67,7 @@ class TestCppStatsWorks(unittest.TestCase):
 #endif
         """
         d = self._get_file_layout(file)
-        feature_dict = get_feature_lines_from_file(d, "unittest.c")
+        feature_dict, fexpr_lines = get_feature_lines_from_file(d, "unittest.c")
 
         self.assertSetEqual(feature_dict.get_line_info(1), set([]))
         self.assertSetEqual(feature_dict.get_line_info(2), set(["Test"]))
@@ -76,4 +76,13 @@ class TestCppStatsWorks(unittest.TestCase):
         self.assertSetEqual(feature_dict.get_line_info(5), set(["Test"]))
         self.assertSetEqual(feature_dict.get_line_info(6), set(["Test"]))
         self.assertSetEqual(feature_dict.get_line_info(7), set([]))
+
+        self.assertSetEqual(fexpr_lines.get_line_info(1), set([]))
+        self.assertSetEqual(fexpr_lines.get_line_info(2), set(["Test"]))
+        self.assertSetEqual(fexpr_lines.get_line_info(3), set(["Test"]))
+        self.assertSetEqual(fexpr_lines.get_line_info(4), set(["!(Test)"]))
+        self.assertSetEqual(fexpr_lines.get_line_info(5), set(["!(Test)"]))
+        self.assertSetEqual(fexpr_lines.get_line_info(6), set(["!(Test)"]))
+        self.assertSetEqual(fexpr_lines.get_line_info(7), set([]))
+
         pass


### PR DESCRIPTION
Until now, only the touched features have been stored as commit dependencies when using the `feature[_file]` tagging options. Now, the corresponding touched feature expressions are stored
additionally.

- Adjust feature extraction and storage mechanisms to handle also feature expressions.
- Adjust emittance of data to the DB for matching new method signatures (tuples!). Break the feature-related test suite temporarily.
- Fix the feature-related tests accordingly.

Furthermore, add node.js, JetBrains and RStudio items to `.gitignore`.