### PR TITLE
Small fixes for mbox download and R package installation

### DIFF
--- a/codeface/R/ml/download.r
+++ b/codeface/R/ml/download.r
@@ -66,10 +66,10 @@ download.mbox <- function(ml, start.date, outfile) {
   ## TODO: Use nntp-pull --verbose, count the number of emitted
   ## lines, and provide a status progress bar.
   cmd <- str_c("nntp-pull --server=news.gmane.org --reget --limit=",
-               num, " ", ml, ">", outfile)
+               num, " '", ml, ">", outfile, "'")
   cat(str_c("Downloading ", num, " messages from ", ml, "\n"))
-#  system(cmd)
-  cat(cmd)
+  cat(cmd, "\n")
+  system(cmd)
 }
 
 #####################################################################

--- a/packages.R
+++ b/packages.R
@@ -23,7 +23,7 @@ if(length(p) > 0) {
 }
 
 
-p <- filter.installed.packages(c("shinyGridster"))
+p <- filter.installed.packages(c("tm.plugin.mail"))
 if(length(p) > 0) {
     devtools::install_github("wolfgangmauerer/tm-plugin-mail/pkg")
 }


### PR DESCRIPTION
With these fixes, the mbox download with `codeface/R/ml/download.r` works again and the correct precondition for the `tm.plugin.mail` is correct again.