### PR TITLE
Fixes to the mailing-list analysis and some other issues

### DIFF
--- a/codeface/R/ml/analysis.r
+++ b/codeface/R/ml/analysis.r
@@ -277,7 +277,7 @@ check.corpus.precon <- function(corp.base) {
         ## replacement
         email <- "could.not.resolve@unknown.tld"
         name <- author
-    } else {
+      } else {
         ## If an email address was detected, use the author
         ## string minus the new email part as name, and construct
         ## a valid name/email combination
@@ -447,7 +447,7 @@ analyse.sub.sequences <- function(conf, corp.base, iter, repo.path,
 
   timestamps <- do.call(c, lapply(seq_along(corp.base$corp),
                                   function(i) meta(corp.base$corp[[i]], tag="datetimestamp")))
-  
+
   loginfo(paste(length(corp.base$corp), "messages in corpus"), logger="ml.analysis")
   loginfo(paste("Date range is", as.character(int_start(iter[[1]])), "to",
       as.character(int_end(iter[[length(iter)]]))), logger="ml.analysis")
@@ -771,7 +771,7 @@ store.mail <- function(conf, forest, corp, ml.id ) {
   dat <- merge(dat, dates.df, by="ID")
   dat$ID <- NULL
   colnames(dat)[which(colnames(dat)=="threadID")] <- "threadId"
-  
+
   # re-order columns to match the order as defined in the database to
   # improve the stability
   dat = dat[c("projectId", "threadId", "mlId", "author", "subject", "creationDate")]

--- a/codeface/R/ml/analysis.r
+++ b/codeface/R/ml/analysis.r
@@ -771,6 +771,10 @@ store.mail <- function(conf, forest, corp, ml.id ) {
   dat <- merge(dat, dates.df, by="ID")
   dat$ID <- NULL
   colnames(dat)[which(colnames(dat)=="threadID")] <- "threadId"
+  
+  # re-order columns to match the order as defined in the database to
+  # improve the stability
+  dat = dat[c("projectId", "threadId", "mlId", "author", "subject", "creationDate")]
 
   res <- dbWriteTable(conf$con, "mail", dat, append=TRUE, row.names=FALSE)
 

--- a/codeface/R/ml/analysis.r
+++ b/codeface/R/ml/analysis.r
@@ -237,6 +237,11 @@ check.corpus.precon <- function(corp.base) {
     ## Trim trailing and leading whitespace
     author <- str_trim(author)
 
+    ## Replace textual ' at  ' with @, sometimes
+    ## we can recover an email
+    author <- sub(' at ', '@', author)
+    author <- sub(' AT ', '@', author)
+
     ## Handle case where author is like
     ## Adrian Prantl via llvm-dev <llvm-dev@lists.llvm.org>
     pattern <- " via [[:print:]]*"
@@ -258,11 +263,6 @@ check.corpus.precon <- function(corp.base) {
                    "<xxxyyy@abc.tld>); attempting to recover from: ", author)
       logdevinfo(msg, logger="ml.analysis")
 
-      ## Replace textual ' at  ' with @, sometimes
-      ## we can recover an email
-      author <- sub(' at ', '@', author)
-      author <- sub(' AT ', '@', author)
-
       ## Check for @ symbol
       r <- regexpr("\\S+@\\S+", author, TRUE)
       email <- substr(author, r, r + attr(r,"match.length")-1)
@@ -282,7 +282,7 @@ check.corpus.precon <- function(corp.base) {
         ## string minus the new email part as name, and construct
         ## a valid name/email combination
         name <- sub(email, "", author, fixed=TRUE)
-        name <- str_trim(name)
+        name <- fix.name(name)
       }
 
       ## In some cases only an email is provided
@@ -293,13 +293,15 @@ check.corpus.precon <- function(corp.base) {
       author <- paste(name, ' <', email, '>', sep="")
     }
     else {
-      ## Verify that the order is correct
+      ## There is a correct email address. Ensure that the order is correct
+      ## and fix cases like "<hans.huber@hubercorp.com> Hans Huber"
+
       ## Get email and name parts
       r <- regexpr("<.+>", author, TRUE)
       if(r[[1]] == 1) {
         email <- substr(author, r, r + attr(r,"match.length")-1)
         name <- sub(email, "", author, fixed=TRUE)
-        name <- str_trim(name)
+        name <- fix.name(name)
         email <- str_trim(email)
         author <- paste(name,email)
       }

--- a/codeface/R/ml/analysis.r
+++ b/codeface/R/ml/analysis.r
@@ -229,7 +229,7 @@ check.corpus.precon <- function(corp.base) {
     }
 
     ## Remove problematic punctuation characters
-    problem.characters <- c("\"", ",", "\\(", "\\)")
+    problem.characters <- c("\"", ",", ";", "\\(", "\\)")
     for (p.char in problem.characters) {
       author <- gsub(p.char, " ", author)
     }

--- a/codeface/R/ml/ml_utils.r
+++ b/codeface/R/ml/ml_utils.r
@@ -433,3 +433,15 @@ ml.thread.loc.to.glob <- function(ml.id.map, loc.id) {
 
   return(global.id)
 }
+
+## Given a name with leading and pending whitespace that is possibly
+## surrounded by braces, return the name proper.
+fix.name <- function(name) {
+    name <- str_trim(name)
+    if (substr(name, 1, 1) == "(" && substr(name, str_length(name),
+                                            str_length(name)) == ")") {
+        name <- substr(name, 2, str_length(name)-1)
+    }
+
+    return (name)
+}

--- a/id_service/id_service.js
+++ b/id_service/id_service.js
@@ -374,7 +374,7 @@ app.getUserFromDB = function(name, email, projectID, response) {
                 } else if (rows.length == 0) {
                     if (!email) {
                         logger.log('error', 'name ' + name + ' (no email ' + email + ') not found in database!');
-                        response.end(JSON.stringify({"error": "name not found"}));
+                        response.end(JSON.stringify({"error": "name \"" + name + "\" not found in the database (no e-mail given)"}));
                     } else {
                         app.getOrUpdateUserInDB(name, email, projectID, response)
                     }

--- a/integration-scripts/install_common.sh
+++ b/integration-scripts/install_common.sh
@@ -14,5 +14,5 @@ sudo DEBIAN_FRONTEND=noninteractive apt-get -qqy install sinntp texlive default-
 	gfortran python-setuptools python-pkg-resources python-numpy python-matplotlib \
 	python-libxml2 python-lxml python-notify python-lxml gcc libarchive12 python-pip \
 	libxml2-dev libcurl4-openssl-dev xorg-dev libx11-dev libgles2-mesa-dev \
-	libglu1-mesa-dev libxt-dev libpoppler-dev libpoppler-glib-dev python-mock
+	libglu1-mesa-dev libxt-dev libpoppler-dev libpoppler-glib-dev python-mock screen
 

--- a/packages.R
+++ b/packages.R
@@ -6,6 +6,33 @@ filter.installed.packages <- function(packageList)  {
     }
 }
 
+# remove package from all libraries (i.e., .libPaths())
+remove.installed.packages <- function(pack) {
+    for (path in .libPaths()) {
+        # try to remove package (hard stop() otherwise, if not existing)
+        tryCatch({
+            remove.packages(pack, path)
+            print(paste("removed previously installed package", pack))
+        }, error = function(e) {
+            # silently ignore errors (the reason would be that a package
+            # is not installed)
+        })
+    }
+}
+
+# (re-)install a package from github
+reinstall.package.from.github <- function(package, url) {
+
+    # if package is installed, remove it completely from all libraries
+    p <- filter.installed.packages(c(package))
+    if(length(p) == 0) {
+        remove.installed.packages(package)
+    }
+
+    #re-install packages
+    devtools::install_github(url)
+}
+
 p <- filter.installed.packages(c("BiRewire", "graph", "Rgraphviz"))
 if(length(p) > 0) {
     source("http://bioconductor.org/biocLite.R")
@@ -13,32 +40,19 @@ if(length(p) > 0) {
 }
 
 p <- filter.installed.packages(c("statnet", "ggplot2", "tm", "optparse",
-                   "igraph", "zoo", "xts", "lubridate", "xtable",
-                   "reshape", "wordnet", "stringr", "yaml", "plyr",
-                   "scales", "gridExtra", "scales", "RMySQL",
-                   "RCurl", "mgcv", "shiny", "dtw", "httpuv", "devtools",
-                   "corrgram", "logging", "png", "rjson", "lsa", "RJSONIO"))
+                                 "igraph", "zoo", "xts", "lubridate", "xtable",
+                                 "reshape", "wordnet", "stringr", "yaml", "plyr",
+                                 "scales", "gridExtra", "scales", "RMySQL",
+                                 "RCurl", "mgcv", "shiny", "dtw", "httpuv", "devtools",
+                                 "corrgram", "logging", "png", "rjson", "lsa", "RJSONIO"))
 if(length(p) > 0) {
     install.packages(p ,dependencies=T)
 }
 
 
-p <- filter.installed.packages(c("tm.plugin.mail"))
-if(length(p) > 0) {
-    devtools::install_github("wolfgangmauerer/tm-plugin-mail/pkg")
-}
-
-p <- filter.installed.packages(c("snatm"))
-if(length(p) > 0) {
-    devtools::install_github("wolfgangmauerer/snatm/pkg")
-}
-
-p <- filter.installed.packages(c("shinyGridster"))
-if(length(p) > 0) {
-    devtools::install_github("wch/shiny-gridster")
-}
-
-p <- filter.installed.packages(c("shinybootstrap2"))
-if(length(p) > 0) {
-	devtools::install_github("rstudio/shinybootstrap2")
-}
+# install following packages from different sources
+# and update existing installations, if needed
+reinstall.package.from.github("tm.plugin.mail", "wolfgangmauerer/tm-plugin-mail/pkg")
+reinstall.package.from.github("snatm", "wolfgangmauerer/snatm/pkg")
+reinstall.package.from.github("shinyGridster", "wch/shiny-gridster")
+reinstall.package.from.github("shinybootstrap2", "rstudio/shinybootstrap2")


### PR DESCRIPTION
This pull request contains many fixes to the mailing-list analysis that have been lying around on other branches (i.e., `mitchell_updates` and `for-upstream`), but also bring much benefit and fix the analysis to a great extent (called *old patches* below). Furthermore, there are additional patches that fix some more things (called *new patches* below).

These main fixes include the following:
- handling the case of proxy e-mails (e.g., `Adrian Prantl via llvm-dev <llvm-dev@lists.llvm.org>`) [29d777d (old)],
- removal of problematic characters in author-mail strings [29d777d (old), 1098eeb (old), ee1e7b4 (new)] and better handling of malformed author-mail strings [e92a6dd (old), e3f58a1 (old, references #34)],
- enhancing the loading of mbox files [29ac3f0 (old), 9d5982e (old)],
- enhancement to storage of e-mails in the `mail` table of the DB and removal of duplicate e-mails [0555675 (old), acf0e2e (old), 8c7263d (new)].

Furthermore, this pull request includes some other patches:
- fix to really re-install GitHub packages in `packages.R` [99666d8 (new)],
- fix of indentation and whitespace in `codeface/R/ml/analysis.r` [3e0a6f8 (new)],
- enhancement to a log message in ID service [4745e9a (new)], and
- addition of the package `screen` to the installation scripts [4f44923 (new)].
