### PR TITLE
README: fix dead link

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ your system. To get shell access on the machine in each case, use
 	vagrant ssh
 
 If vagrant is not yet installed on your system, please consult
-the corresponding [wiki page] (https://github.com/siemens/codeface/wiki/Runnning-codeface-with-Vagrant).
+the corresponding [wiki page](https://github.com/siemens/codeface/wiki/Running-codeface-with-Vagrant).
 
 ## Analysing Projects
 ### Concept


### PR DESCRIPTION
The old link pointed to a non-existing page. Fix the link. Additionally,
remove the whitespace character for proper link appearance in browsers.

Fixes: a8f0b6513a ("Improve documentation")
Signed-off-by: Ralf Ramsauer <ralf.ramsauer@oth-regensburg.de>